### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ferm (2.4-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:07:33 +0100
+
 ferm (2.4-1) unstable; urgency=medium
 
   * [2bd37ee] New upstream version 2.4

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 3.9.3
 Build-Depends: debhelper (>= 9), dh-systemd
 Build-Depends-Indep: po-debconf
 Vcs-Browser: https://github.com/formorer/pkg-ferm
-Vcs-Git: git://github.com/formorer/pkg-ferm.git
+Vcs-Git: https://github.com/formorer/pkg-ferm.git
 Homepage: http://ferm.foo-projects.org/
 
 Package: ferm


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
