### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Alexander Wirt <formorer@debian.org>
 Standards-Version: 3.9.3
-Build-Depends: debhelper (>= 9), dh-systemd
+Build-Depends: debhelper (>= 9), debhelper (>= 9.20160709)
 Build-Depends-Indep: po-debconf
 Vcs-Browser: https://github.com/formorer/pkg-ferm
 Vcs-Git: git://github.com/formorer/pkg-ferm.git
@@ -11,10 +11,10 @@ Homepage: http://ferm.foo-projects.org/
 
 Package: ferm
 Architecture: all
-Depends: debconf (>= 1.2.0),
-         iptables (>= 1.3),
-         lsb-base (>= 3.0-6),
-         perl (>= 5.6),
+Depends: debconf,
+         iptables,
+         lsb-base,
+         perl,
          ${misc:Depends}
 Recommends: libnet-dns-perl
 Description: maintain and setup complicated firewall rules


### PR DESCRIPTION
Remove unnecessary constraints.

## Debdiff

These changes affect the binary packages:

File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Depends: {+debconf, iptables, lsb-base, perl,+} debconf (>= [-1.2.0), iptables (>= 1.3), lsb-base (>= 3.0-6), perl (>= 5.6)-] {+0.5) | debconf-2.0+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/f3d6c1d1-3bd3-4d79-8392-7388098060bd/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/f3d6c1d1-3bd3-4d79-8392-7388098060bd/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/scrub-obsolete), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/ferm/f3d6c1d1-3bd3-4d79-8392-7388098060bd.